### PR TITLE
feat: Implement real-time updates for Kanban board

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -77,9 +77,6 @@ io.on('connection', (socket) => {
     console.log(`User ${socket.userId} left board ${boardId}`);
   });
 
-  // Remove all these client event listeners - they're causing the loop
-  // The backend controllers will handle emitting events after database operations
-
   socket.on('disconnect', () => {
     console.log('User disconnected:', socket.id, 'User ID:', socket.userId);
   });

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -40,6 +40,8 @@ import {
   addSectionLocal,
   updateSectionLocal,
   deleteSectionLocal,
+  moveTaskLocal,
+  deleteTaskLocal,
 } from '../store/kanbanSlice';
 
 const Board = () => {
@@ -97,8 +99,7 @@ const Board = () => {
     });
 
     socket.on('task-moved', (data) => {
-      // Handle task movement in your store
-      // You'll need to implement this in your kanbanSlice
+      dispatch(moveTaskLocal(data));
     });
 
     socket.on('task-deleted', (data) => {

--- a/src/store/kanbanSlice.js
+++ b/src/store/kanbanSlice.js
@@ -135,6 +135,33 @@ const kanbanSlice = createSlice({
         section.tasks = section.tasks.filter((task) => task._id !== taskId);
       }
     },
+    moveTaskLocal: (state, action) => {
+      const { taskId, sourceSectionId, destinationSectionId, task } =
+        action.payload;
+
+      const sourceSection = state.sections.find(
+        (s) => s._id === sourceSectionId
+      );
+      const destSection = state.sections.find(
+        (s) => s._id === destinationSectionId
+      );
+
+      if (sourceSection && destSection) {
+        // Remove task from source section if it exists
+        const taskIndex = sourceSection.tasks.findIndex(
+          (t) => t._id === taskId
+        );
+        if (taskIndex > -1) {
+          sourceSection.tasks.splice(taskIndex, 1);
+        }
+
+        // Add task to destination section
+        if (!destSection.tasks) {
+          destSection.tasks = [];
+        }
+        destSection.tasks.push(task);
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -238,6 +265,7 @@ export const {
   addTaskLocal,
   updateTaskLocal,
   deleteTaskLocal,
+  moveTaskLocal,
 } = kanbanSlice.actions;
 
 export default kanbanSlice.reducer;


### PR DESCRIPTION
This commit introduces the necessary changes to enable real-time updates on the Kanban board using Socket.IO.

The main changes are:
- Implemented the `moveTaskLocal` reducer in `kanbanSlice.js` to handle moving tasks between sections in the Redux state.
- Implemented the `task-moved` event handler in `Board.jsx` to dispatch the `moveTaskLocal` action when a `task-moved` event is received from the server.
- Removed confusing comments from `backend/server.js`.