### PR TITLE
fix: Prevent task duplication on drag-and-drop

### DIFF
--- a/src/store/kanbanSlice.js
+++ b/src/store/kanbanSlice.js
@@ -232,28 +232,6 @@ const kanbanSlice = createSlice({
           section.tasks = section.tasks.filter(
             (t) => t._id !== action.payload.taskId
           );
-      })
-      .addCase(moveTask.fulfilled, (state, action) => {
-        const { taskId, sourceSectionId, destinationSectionId, task } =
-          action.payload;
-
-        const sourceSection = state.sections.find(
-          (s) => s._id === sourceSectionId
-        );
-        const destSection = state.sections.find(
-          (s) => s._id === destinationSectionId
-        );
-
-        if (sourceSection && destSection) {
-          // Remove task from source section
-          sourceSection.tasks = sourceSection.tasks.filter(
-            (t) => t._id !== taskId
-          );
-
-          // Add task to destination section
-          if (!destSection.tasks) destSection.tasks = [];
-          destSection.tasks.push(task);
-        }
       });
   },
 });


### PR DESCRIPTION
This commit resolves an issue where tasks would duplicate on the frontend for the user performing a drag-and-drop action.

The duplication was caused by the frontend state being updated twice: once from the optimistic update in the `moveTask.fulfilled` reducer, and a second time from the real-time socket event.

This fix removes the optimistic update by deleting the `moveTask.fulfilled` reducer. The frontend now relies solely on the socket event to update the state after a task is moved, ensuring consistency and preventing duplication.