### PR TITLE
fix: Correct user creation logic in signup service

### DIFF
--- a/backend/src/features/user/user.service.js
+++ b/backend/src/features/user/user.service.js
@@ -35,6 +35,10 @@ class UserService {
       throw new Error("Invalid photo URL. Must be a .jpg, .jpeg, or .png link.");
     }
 
+    // Create and save user
+    const newUser = new User({ name, email, password: hashedPassword, userPhoto: finalPhoto });
+    await newUser.save();
+
     const token = jwt.sign(
       { userId: newUser.id, email: newUser.email }, // Include userId here
       process.env.JWT_SECRET,
@@ -50,10 +54,6 @@ class UserService {
         email: newUser.email
       }
     };
-
-    // Create and save user
-    const newUser = new User({ name, email, password: hashedPassword, userPhoto: finalPhoto });
-    return await newUser.save();
   }
 
   static async login(email, password) {


### PR DESCRIPTION
This commit fixes a critical bug in the user signup functionality. The previous code attempted to generate a JWT token and return a response using the `newUser` object before it was defined, causing a `ReferenceError` and preventing user creation.

The code has been reordered to ensure that the `newUser` object is created and saved to the database *before* the JWT token is generated and the response is returned. This resolves the signup failure.