### PR TITLE
fix: Prevent task duplication on add task

### DIFF
--- a/src/store/kanbanSlice.js
+++ b/src/store/kanbanSlice.js
@@ -205,15 +205,6 @@ const kanbanSlice = createSlice({
       .addCase(deleteSection.fulfilled, (state, action) => {
         state.sections = state.sections.filter((s) => s._id !== action.payload);
       })
-      .addCase(addTask.fulfilled, (state, action) => {
-        const { sectionId, task } = action.payload;
-        const section = state.sections.find((s) => s._id === sectionId);
-
-        if (section) {
-          if (!section.tasks) section.tasks = [];
-          section.tasks.push({ ...task });
-        }
-      })
       .addCase(updateTask.fulfilled, (state, action) => {
         const { sectionId, taskId, updatedTask } = action.payload;
         const section = state.sections.find((s) => s._id === sectionId);


### PR DESCRIPTION
This commit resolves an issue where tasks would duplicate on the frontend for the user performing an add task action.

The duplication was caused by the frontend state being updated twice: once from the optimistic update in the `addTask.fulfilled` reducer, and a second time from the real-time socket event.

This fix removes the optimistic update by deleting the `addTask.fulfilled` reducer. The frontend now relies solely on the socket event to update the state after a task is added, ensuring consistency and preventing duplication.