### PR TITLE
refactor: Simplify drag-and-drop to be purely socket-driven

### DIFF
--- a/backend/src/features/tasks/task.controller.js
+++ b/backend/src/features/tasks/task.controller.js
@@ -67,7 +67,7 @@ export default class TaskController {
                 taskId,
                 sourceSectionId,
                 destinationSectionId,
-                task: task.toObject(),
+                task,
                 boardId: 'default-board'
             });
             

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -53,12 +53,14 @@ const Section = memo(({ section }) => {
     accept: "TASK",
     drop: (item) => {
       if (item.sourceSectionId !== section._id) {
-        dispatch(moveTask({
-          taskId: item.taskId,
-          sourceSectionId: item.sourceSectionId,
-          destinationSectionId: section._id,
-          task: item.task
-        }));
+        // Emit socket event for real-time update
+        if (socket) {
+          socket.emit('move-task', {
+            taskId: item.taskId,
+            sourceSectionId: item.sourceSectionId,
+            destinationSectionId: section._id
+          });
+        }
       }
     },
     collect: (monitor) => ({


### PR DESCRIPTION
Refactors the real-time task drag-and-drop feature to use a simplified, purely socket-driven architecture, following user feedback to "make it simple".

- The client now emits a single `move-task` socket event when a task is dropped. The previous logic that also dispatched a Redux thunk to call an API has been removed.
- A new socket listener for `move-task` has been added to `server.js`. This single listener is now responsible for both updating the database via `TaskModel.moveTask` and broadcasting the `task-moved` event to all clients.
- This new architecture is simpler, removes a race condition between an API call and a socket event, and consolidates the logic in one place.